### PR TITLE
LPS-22828

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/util.jspf
+++ b/portal-web/docroot/html/portlet/document_library/util.jspf
@@ -28,11 +28,11 @@ private static final String _getFileEntryImage(FileEntry fileEntry, ThemeDisplay
 }
 
 private static final String _getPreviewURL(FileEntry fileEntry, FileVersion fileVersion, ThemeDisplay themeDisplay, String queryString) {
-	return _getPreviewURL(fileEntry, fileVersion, themeDisplay, queryString, true);
+	return _getPreviewURL(fileEntry, fileVersion, themeDisplay, queryString, false);
 }
 
-private static final String _getPreviewURL(FileEntry fileEntry, FileVersion fileVersion, ThemeDisplay themeDisplay, String queryString, boolean appendToken) {
-	StringBundler sb = new StringBundler(13);
+private static final String _getPreviewURL(FileEntry fileEntry, FileVersion fileVersion, ThemeDisplay themeDisplay, String queryString, boolean mediaGallery) {
+	StringBundler sb = new StringBundler(7);
 
 	sb.append(themeDisplay.getPortalURL());
 	sb.append(themeDisplay.getPathContext());
@@ -41,20 +41,36 @@ private static final String _getPreviewURL(FileEntry fileEntry, FileVersion file
 	sb.append(StringPool.SLASH);
 	sb.append(fileEntry.getFolderId());
 	sb.append(StringPool.SLASH);
+
+	String preface = sb.toString();
+
+	sb = new StringBundler(6);
+
 	sb.append(HttpUtil.encodeURL(HtmlUtil.unescape(fileEntry.getTitle())));
 	sb.append("?version=");
 	sb.append(fileVersion.getVersion());
+	sb.append(queryString);
 
-	if (appendToken) {
+	if (mediaGallery) {
+		String media = HtmlUtil.escapeURL(sb.toString());
+
+		if (queryString.contains("audio")) {
+			media += "&supportedAudio=1&mediaGallery=1";
+		}
+		else {
+			media += "&supportedVideo=1&mediaGallery=1";
+		}
+
+		return preface + media;
+	}
+	else {
 		sb.append("&t=");
 
 		Date modifiedDate = fileVersion.getModifiedDate();
 
 		sb.append(modifiedDate.getTime());
+
+		return preface + sb.toString();
 	}
-
-	sb.append(queryString);
-
-	return sb.toString();
 }
 %>

--- a/portal-web/docroot/html/portlet/image_gallery_display/view_images.jspf
+++ b/portal-web/docroot/html/portlet/image_gallery_display/view_images.jspf
@@ -50,12 +50,8 @@
 						String href = themeDisplay.getPathThemeImages() + "/file_system/large/" + DLUtil.getGenericName(fileEntry.getExtension()) + ".png";
 						String src = themeDisplay.getPathThemeImages() + "/file_system/large/" + DLUtil.getGenericName(fileEntry.getExtension()) + ".png";
 
-						int playerHeight = 500;
-
 						if (AudioProcessor.hasAudio(fileVersion)) {
-							href = _getPreviewURL(fileEntry, fileVersion, themeDisplay, HtmlUtil.escapeURL("&audioPreview=1") + "&supportedAudio=1&mediaGallery=1", false);
-
-							playerHeight = 43;
+							href = _getPreviewURL(fileEntry, fileVersion, themeDisplay, "&audioPreview=1", true);
 						}
 						else if (ImageProcessor.hasImages(fileVersion)) {
 							href = _getPreviewURL(fileEntry, fileVersion, themeDisplay, StringPool.BLANK);
@@ -66,12 +62,21 @@
 							src = _getPreviewURL(fileEntry, fileVersion, themeDisplay, "&previewFileIndex=1");
 						}
 						else if (VideoProcessor.hasVideo(fileVersion)) {
-							href = _getPreviewURL(fileEntry, fileVersion, themeDisplay, HtmlUtil.escapeURL("&videoPreview=1") + "&supportedVideo=1&mediaGallery=1", false);
+							href = _getPreviewURL(fileEntry, fileVersion, themeDisplay, "&videoPreview=1", true);
 							src = _getPreviewURL(fileEntry, fileVersion, themeDisplay, "&videoThumbnail=1");
+						}
+
+						String dataOptions = StringPool.BLANK;
+
+						if (supportedAudio) {
+							dataOptions = "data-options=\"height=43&width=640\"";
+						}
+						else if (supportedVideo) {
+							dataOptions = "data-options=\"height=500&width=640&thumbnailURL=" + HtmlUtil.escapeURL(src) + "\"";
 						}
 						%>
 
-						<a class="image-thumbnail preview" <%= (supportedAudio || supportedVideo) ? "data-options=\"height=" + playerHeight + "&thumbnailURL=" + HtmlUtil.escapeURL(_getPreviewURL(fileEntry, fileVersion, themeDisplay, "&videoThumbnail=1")) + "&width=640\"" : StringPool.BLANK %> href="<%= href %>" fileEntryId="<%= fileEntry.getFileEntryId() %>" title="<%= HtmlUtil.escape(fileEntry.getTitle()) + " - " + HtmlUtil.escape(fileEntry.getDescription()) %>">
+						<a class="image-thumbnail preview" <%= dataOptions %> href="<%= href %>" fileEntryId="<%= fileEntry.getFileEntryId() %>" title="<%= HtmlUtil.escape(fileEntry.getTitle()) + " - " + HtmlUtil.escape(fileEntry.getDescription()) %>">
 							<img alt="<%= HtmlUtil.escape(fileEntry.getTitle()) + " - " + HtmlUtil.escape(fileEntry.getDescription()) %>" border="no" src="<%= src %>" />
 
 							<span class="image-title"><%= HtmlUtil.escape(fileVersion.getTitle()) %></span>


### PR DESCRIPTION
Hey Iliyan,

Can you look over this code.  I tried to consolidate the changes in util.jspf.  As it is, it is working… though not pretty.

One question I have for you is why I actually need to go through the extra step in util.jspf to escape the title + queryString but not the rest of the URL (compare with view_images.jspf:75).  It seems like this is some odd limitation in aui-media-viewer-plugin.js?

Alex
