### PR TITLE
LPS-24341 Unable to remove translations

### DIFF
--- a/portal-web/docroot/html/js/liferay/auto_fields.js
+++ b/portal-web/docroot/html/js/liferay/auto_fields.js
@@ -398,7 +398,7 @@ AUI().add(
 					_isHiddenRow: function(row) {
 						var instance = this;
 
-						return row.hasClass(row._hideClass);
+						return row.hasClass('aui-helper-hidden');
 					},
 
 					_makeSortable: function(sortableHandle) {


### PR DESCRIPTION
We need to check if the node contains the 'aui-helper-hidden' class  instead of "node._hideClass" because this last one returns null.
