### PR TITLE
LPS-27745: p_auth is missing for navigation.js

### DIFF
--- a/portal-web/docroot/html/js/liferay/navigation.js
+++ b/portal-web/docroot/html/js/liferay/navigation.js
@@ -660,6 +660,7 @@ AUI.add(
 								languageId: themeDisplay.getLanguageId(),
 								layoutId: themeDisplay.getLayoutId(),
 								name: pageTitle,
+								p_auth: Liferay.authToken,
 								privateLayout: themeDisplay.isPrivateLayout()
 							};
 


### PR DESCRIPTION
Iliyan, may I ask you for a review? It is a simple one - I forgot to add p_auth token into navigation.js, which calls also one of JSON Services.

Thank you!

EDIT: Please, if you don't have time tell me so as I can reassign it to somebody else, it's urgent! Thank you.

-- tom
