### PR TITLE
LPS-28085 Different permission requirements at Manage Pages and Navigati...

### DIFF
--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -121,7 +121,6 @@ if (layout != null) {
 				new Liferay.Navigation(
 					{
 						hasAddLayoutPermission: <%= GroupPermissionUtil.contains(permissionChecker, scopeGroupId, ActionKeys.ADD_LAYOUT) %>,
-						hasPermission: <%= GroupPermissionUtil.contains(permissionChecker, scopeGroupId, ActionKeys.MANAGE_LAYOUTS) %>,
 						layoutIds: [
 
 							<%

--- a/portal-web/docroot/html/js/liferay/navigation.js
+++ b/portal-web/docroot/html/js/liferay/navigation.js
@@ -13,7 +13,6 @@ AUI.add(
 		 * OPTIONS
 		 *
 		 * Required
-		 * hasPermission {boolean}: Whether the current user has permission to modify the navigation
 		 * layoutIds {array}: The displayable layout ids.
 		 * layoutSetBranchId {String}: The id of the layout set branch (when branching is enabled).
 		 * navBlock {string|object}: A selector or DOM element of the navigation.
@@ -23,10 +22,6 @@ AUI.add(
 			{
 				ATTRS: {
 					hasAddLayoutPermission: {
-						value: false
-					},
-
-					hasPermission: {
 						value: false
 					},
 
@@ -43,8 +38,7 @@ AUI.add(
 						getter: function(value) {
 							var instance = this;
 
-							return instance.get('hasPermission') &&
-									instance.get('navBlock').hasClass('modify-pages');
+							return instance.get('navBlock').hasClass('modify-pages');
 						},
 						value: false
 					},
@@ -53,8 +47,7 @@ AUI.add(
 						getter: function(value) {
 							var instance = this;
 
-							return instance.get('hasPermission') &&
-									instance.get('navBlock').hasClass('sort-pages');
+							return instance.get('navBlock').hasClass('sort-pages');
 						},
 						value: false
 					},
@@ -283,7 +276,7 @@ AUI.add(
 						var instance = this;
 
 						if (instance.get('isModifiable')) {
-							var currentItem = instance.get('navBlock').one('li.selected');
+							var currentItem = instance.get('navBlock').one('li.selected.lfr-nav-updateable');
 
 							if (currentItem) {
 								var currentLink = currentItem.one('a');


### PR DESCRIPTION
As described in ticket LPS-28085, permissions were not working the same in Manage-Pages and Navigation. When building navigation at navigation.js, the variable hasPermission is being checked (apart from the corresponding permission) to make nav items deletable, updateable or shortable. This variable is set at bottom_js.jspf based on the MANAGE_LAYOUT permission of the current user. However, at layouts_admin/edit_layout.jsp this permission is not checked for the same actions. 

I consider that hasPermission is no longer necessary, since we already check delete/update permissions for every item at navigation. 

I've also modified the _makeEditable function at navigation.js so that only items with class selected AND lfr-nav-updateable can be edited with double-click.
