### PR TITLE
LPS-20127 Manage Pages - Dragging a child page onto a parent page and saving does not change the display order

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/tree_js.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/tree_js.jsp
@@ -595,7 +595,7 @@ if (!selectableTree) {
 				dropAppend: function(event) {
 					var tree = event.tree;
 
-					var index = tree.dragNode.get('parentNode').indexOf(tree.dragNode);
+					var index = tree.dragNode.get('parentNode').getChildrenLength() - 1;
 
 					TreeUtil.updateLayoutParent(
 						TreeUtil.extractPlid(tree.dragNode),


### PR DESCRIPTION
Hello Iliyan!

The problem with this ticket was that when you changed the order by dragging and dropping a child page to a parent node, the changes did not get applied. The reason was that the old codeline gave us a bad result, for example when it should have given 2, it gave 1. This is becouse by the time it got evaluated, it actualy was 1, so basicly the given parent node only got the dragged node, after the eval was done, so it returned with the "old index". 

Regards,
Levente
