### PR TITLE
LPS-35671 Show alternative localized friendly urls

### DIFF
--- a/portal-impl/src/VM_liferay.vm
+++ b/portal-impl/src/VM_liferay.vm
@@ -88,6 +88,12 @@ img, .png {
 	#end
 #end
 
+#macro (layout_friendly_url_suggestions)
+	#set ($layout_friendly_url_suggestions_tag = $theme.getLayoutFriendlyURLSuggestionsTag())
+
+	$layout_friendly_url_suggestions_tag.runTag()
+#end
+
 #macro (silently $foo)
 	#set ($foo = $foo)
 #end

--- a/portal-web/docroot/html/taglib/ui/layout_friendly_url_suggestions/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/layout_friendly_url_suggestions/page.jsp
@@ -1,0 +1,61 @@
+<%--
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/html/taglib/init.jsp" %>
+
+<%
+List<String> alternativeLayoutFriendlyURLs = (List<String>)SessionMessages.get(request, "alternativeLayoutFriendlyUrls");
+
+if ((alternativeLayoutFriendlyURLs != null) && !alternativeLayoutFriendlyURLs.isEmpty()) {
+	List<String> alternativeFriendlyURLLinks = new ArrayList<String>();
+%>
+
+	<div class="helper-hidden alert alert-info" id="alternativeLayoutFriendlyURLNode">
+
+		<%
+		for (String alternativeLayoutFriendlyURL : alternativeLayoutFriendlyURLs) {
+			StringBundler sb = new StringBundler(5);
+
+			sb.append("<a href=\"");
+			sb.append(alternativeLayoutFriendlyURL);
+			sb.append("\">");
+			sb.append(alternativeLayoutFriendlyURL);
+			sb.append("</a>");
+
+			alternativeFriendlyURLLinks.add(sb.toString());
+		}
+		%>
+
+		<%= ListUtil.toString(alternativeFriendlyURLLinks, StringPool.BLANK, StringPool.COMMA) %>
+	</div>
+
+	<aui:script use="liferay-notice">
+		var alternativeLayoutFriendlyURLNode = A.one('#alternativeLayoutFriendlyURLNode')
+
+		var banner = new Liferay.Notice(
+			{
+				content: alternativeLayoutFriendlyURLNode.html(),
+				noticeClass: 'hide',
+				toggleText: false
+			}
+		);
+
+		banner.show();
+	</aui:script>
+
+<%
+}
+%>

--- a/portal-web/docroot/html/themes/classic/_diffs/templates/portal_normal.vm
+++ b/portal-web/docroot/html/themes/classic/_diffs/templates/portal_normal.vm
@@ -18,6 +18,8 @@ $theme.include($body_top_include)
 
 #dockbar()
 
+#layout_friendly_url_suggestions()
+
 <div class="container-fluid" id="wrapper">
 	<header id="banner" role="banner">
 

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -2207,6 +2207,11 @@
 		</attribute>
 	</tag>
 	<tag>
+		<name>layout-friendly-url-suggestions</name>
+		<tag-class>com.liferay.taglib.ui.LayoutFriendlyURLSuggestionsTag</tag-class>
+		<body-content>JSP</body-content>
+	</tag>
+	<tag>
 		<name>logo-selector</name>
 		<tag-class>com.liferay.taglib.ui.LogoSelectorTag</tag-class>
 		<body-content>JSP</body-content>

--- a/util-taglib/src/com/liferay/taglib/ui/LayoutFriendlyURLSuggestionsTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/LayoutFriendlyURLSuggestionsTag.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.taglib.ui;
+
+import com.liferay.taglib.util.IncludeTag;
+
+/**
+ * @author Sergio González
+ */
+public class LayoutFriendlyURLSuggestionsTag extends IncludeTag {
+
+	@Override
+	protected String getPage() {
+		return _PAGE;
+	}
+
+	private static final String _PAGE =
+		"/html/taglib/ui/layout_friendly_url_suggestions/page.jsp";
+
+}

--- a/util-taglib/src/com/liferay/taglib/util/DummyVelocityTaglib.java
+++ b/util-taglib/src/com/liferay/taglib/util/DummyVelocityTaglib.java
@@ -28,6 +28,7 @@ import com.liferay.taglib.ui.DiscussionTag;
 import com.liferay.taglib.ui.FlagsTag;
 import com.liferay.taglib.ui.IconTag;
 import com.liferay.taglib.ui.JournalArticleTag;
+import com.liferay.taglib.ui.LayoutFriendlyURLSuggestionsTag;
 import com.liferay.taglib.ui.MySitesTag;
 import com.liferay.taglib.ui.PngImageTag;
 import com.liferay.taglib.ui.RatingsTag;
@@ -185,6 +186,13 @@ public class DummyVelocityTaglib implements VelocityTaglib {
 
 	@Override
 	public JournalArticleTag getJournalArticleTag() throws Exception {
+		return null;
+	}
+
+	@Override
+	public LayoutFriendlyURLSuggestionsTag getLayoutFriendlyURLSuggestionsTag()
+		throws Exception {
+
 		return null;
 	}
 
@@ -387,6 +395,9 @@ public class DummyVelocityTaglib implements VelocityTaglib {
 			String formName, String formAction, String name,
 			String[] languageIds, int displayStyle)
 		throws Exception {
+	}
+
+	public void layoutFriendlyURLSuggestions() throws Exception {
 	}
 
 	@Override

--- a/util-taglib/src/com/liferay/taglib/util/VelocityTaglib.java
+++ b/util-taglib/src/com/liferay/taglib/util/VelocityTaglib.java
@@ -27,6 +27,7 @@ import com.liferay.taglib.ui.DiscussionTag;
 import com.liferay.taglib.ui.FlagsTag;
 import com.liferay.taglib.ui.IconTag;
 import com.liferay.taglib.ui.JournalArticleTag;
+import com.liferay.taglib.ui.LayoutFriendlyURLSuggestionsTag;
 import com.liferay.taglib.ui.MySitesTag;
 import com.liferay.taglib.ui.PngImageTag;
 import com.liferay.taglib.ui.RatingsTag;
@@ -130,6 +131,9 @@ public interface VelocityTaglib {
 	public IconTag getIconTag() throws Exception;
 
 	public JournalArticleTag getJournalArticleTag() throws Exception;
+
+	public LayoutFriendlyURLSuggestionsTag getLayoutFriendlyURLSuggestionsTag()
+		throws Exception;
 
 	public LayoutTag getLayoutTag() throws Exception;
 
@@ -248,6 +252,8 @@ public interface VelocityTaglib {
 			String formName, String formAction, String name,
 			String[] languageIds, int displayStyle)
 		throws Exception;
+
+	public void layoutFriendlyURLSuggestions() throws Exception;
 
 	public void layoutIcon(Layout layout) throws Exception;
 

--- a/util-taglib/src/com/liferay/taglib/util/VelocityTaglibImpl.java
+++ b/util-taglib/src/com/liferay/taglib/util/VelocityTaglibImpl.java
@@ -59,6 +59,7 @@ import com.liferay.taglib.ui.IconTag;
 import com.liferay.taglib.ui.JournalArticleTag;
 import com.liferay.taglib.ui.JournalContentSearchTag;
 import com.liferay.taglib.ui.LanguageTag;
+import com.liferay.taglib.ui.LayoutFriendlyURLSuggestionsTag;
 import com.liferay.taglib.ui.MySitesTag;
 import com.liferay.taglib.ui.PngImageTag;
 import com.liferay.taglib.ui.RatingsTag;
@@ -412,6 +413,18 @@ public class VelocityTaglibImpl implements VelocityTaglib {
 	}
 
 	@Override
+	public LayoutFriendlyURLSuggestionsTag getLayoutFriendlyURLSuggestionsTag()
+		throws Exception {
+
+		LayoutFriendlyURLSuggestionsTag layoutFriendlyURLSuggestionsTag =
+			new LayoutFriendlyURLSuggestionsTag();
+
+		setUp(layoutFriendlyURLSuggestionsTag);
+
+		return layoutFriendlyURLSuggestionsTag;
+	}
+
+	@Override
 	public LayoutTag getLayoutTag() throws Exception {
 		LayoutTag layoutTag = new LayoutTag();
 
@@ -709,6 +722,13 @@ public class VelocityTaglibImpl implements VelocityTaglib {
 		languageTag.setName(name);
 
 		languageTag.runTag();
+	}
+
+	public void layoutFriendlyURLSuggestions() throws Exception {
+		LayoutFriendlyURLSuggestionsTag layoutFriendlyURLSuggestionsTag =
+			new LayoutFriendlyURLSuggestionsTag();
+
+		layoutFriendlyURLSuggestionsTag.runTag();
 	}
 
 	@Override


### PR DESCRIPTION
Hey Iliyan,

In order to test it you need to create some layouts and localize the friendly urls. You can create a new page called "Documents" and set the friendly urls to be: English -> /documents Spanish /documentos.

Then, the message with the alternative friendly urls will be displayed when you create urls like this:

http://localhost:8080/es/web/guest/documents
http://localhost:8080/en/web/guest/documentos

because in those cases the locale of the URL doesn't match with the locale of the friendly url

Let me know if you have any question.

Thanks!
