### PR TITLE
LPS-37318 After unchecking the parent control, the summary still displays the labels of the child controls

### DIFF
--- a/portal-web/docroot/html/js/liferay/util.js
+++ b/portal-web/docroot/html/js/liferay/util.js
@@ -1755,7 +1755,7 @@
 	Liferay.provide(
 		Util,
 		'toggleBoxes',
-		function(checkBoxId, toggleBoxId, displayWhenUnchecked) {
+		function(checkBoxId, toggleBoxId, displayWhenUnchecked, toggleChildCheckboxes) {
 			var checkBox = A.one('#' + checkBoxId);
 			var toggleBox = A.one('#' + toggleBoxId);
 
@@ -1773,10 +1773,26 @@
 					toggleBox.toggle();
 				}
 
+				var childCheckboxes;
+
 				checkBox.on(
 					EVENT_CLICK,
 					function() {
 						toggleBox.toggle();
+
+						if (toggleChildCheckboxes) {
+							if (!childCheckboxes) {
+								childCheckboxes = toggleBox.all('input[type=checkbox]');
+							}
+
+							var checked = checkBox.get('checked');
+
+							childCheckboxes.each(
+								function(item, index, collection) {
+									item.set('checked', checked);
+								}
+							);
+						}
 					}
 				);
 			}

--- a/portal-web/docroot/html/portlet/layouts_admin/render_controls.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/render_controls.jsp
@@ -67,7 +67,7 @@ for (int i = 0; i < controls.length; i++) {
 					</ul>
 
 					<aui:script>
-						Liferay.Util.toggleBoxes('<portlet:namespace /><%= control.getNamespacedControlName() %>Checkbox','<portlet:namespace /><%= control.getNamespacedControlName() %>Controls');
+						Liferay.Util.toggleBoxes('<portlet:namespace /><%= control.getNamespacedControlName() %>Checkbox','<portlet:namespace /><%= control.getNamespacedControlName() %>Controls', false, true);
 					</aui:script>
 				</c:if>
 			</c:when>


### PR DESCRIPTION
Hey Iliyan,

We need to make sure that all checkboxes inside the toggled box are unchecked. I've modified the existing toggleBoxes function to achieve this. Could you please review it?

Thanks!

@juliocamarero
