### PR TITLE
LPS-43909 NTLM is not working for IE11

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/BrowserSnifferImpl.java
+++ b/portal-impl/src/com/liferay/portal/servlet/BrowserSnifferImpl.java
@@ -513,7 +513,9 @@ public class BrowserSnifferImpl implements BrowserSniffer {
 	}
 
 	protected boolean isIe(String userAgent) {
-		if (userAgent.contains("msie") && !userAgent.contains("opera")) {
+		if ((userAgent.contains("msie") || userAgent.contains("trident")) &&
+			!userAgent.contains("opera")) {
+
 			return true;
 		}
 

--- a/portal-impl/test/unit/com/liferay/portal/servlet/BrowserSnifferImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/BrowserSnifferImplTest.java
@@ -83,6 +83,53 @@ public class BrowserSnifferImplTest {
 	}
 
 	@Test
+	public void testIsIe() throws IOException {
+		UnsyncBufferedReader unsyncBufferedReader =
+			getResourceAsUnsyncBufferedReader("dependencies/user_agents.csv");
+
+		boolean ie = false;
+		String line = null;
+
+		while ((line = unsyncBufferedReader.readLine()) != null) {
+			line = line.trim();
+
+			if (line.isEmpty()) {
+				continue;
+			}
+
+			if (line.contains("## IE")) {
+				ie = true;
+
+				continue;
+			}
+
+			if (ie && (line.charAt(0) == CharPool.POUND)) {
+				break;
+			}
+
+			if (ie) {
+				MockHttpServletRequest mockHttpServletRequest =
+					new MockHttpServletRequest();
+
+				mockHttpServletRequest.addHeader(HttpHeaders.USER_AGENT, line);
+
+				Assert.assertTrue(
+					_browserSnifferImpl.isIe(mockHttpServletRequest));
+			}
+		}
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.addHeader(
+			HttpHeaders.USER_AGENT,
+			"Opera 12 var1, 12.14, 9.80, opera/9.80 (windows nt 6.0)" +
+				" presto/2.12.388 version/12.14");
+
+		Assert.assertFalse(_browserSnifferImpl.isIe(mockHttpServletRequest));
+	}
+
+	@Test
 	public void testIsMobile() throws IOException {
 		UnsyncBufferedReader unsyncBufferedReader =
 			getResourceAsUnsyncBufferedReader("dependencies/user_agents.csv");

--- a/portal-impl/test/unit/com/liferay/portal/servlet/dependencies/user_agents.csv
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/dependencies/user_agents.csv
@@ -1,5 +1,6 @@
 ## 
 ## See http://www.useragentstring.com/pages/useragentstring.php
+## See http://msdn.microsoft.com/en-us/library/ie/hh869301(v=vs.85).aspx for IE11
 ##
 
 ## Android
@@ -53,6 +54,11 @@ Firefox 22 var2, 22.0, 22.0, mozilla/5.0 (windows nt 6.1; win64; x64; rv:22.0) g
 Firefox 22 var3, 22.0, 22.0, mozilla/5.0 (windows nt 6.1; rv:22.0) gecko/20130405 firefox/22.0
 Firefox 21 var1, 21.0, 16.0, mozilla/5.0 (windows nt 6.2; win64; x64; rv:16.0.1) gecko/20121011 firefox/21.0.1
 Firefox 21 var2, 21.0, 16.0, mozilla/5.0 (windows nt 6.1; win64; x64; rv:16.0.1) gecko/20121011 firefox/21.0.1
+
+## IE 11.0
+
+IE 11 var1, , 11.0, mozilla/5.0 (windows nt 6.3; trident/7.0; rv:11.0) like gecko
+IE 11 var2, , 11.0, mozilla/5.0 (windows nt 6.1; trident/7.0; rv:11.0) like gecko
 
 ## IE 10.6
 


### PR DESCRIPTION
Hi @ipeychev, @juliocamarero,

IE11 sends this user agent:
mozilla/5.0 (windows nt 6.1; wow64; trident/7.0; rv:11.0) like gecko

So we can't use "msie" to recognise it. We have to use "trident" as the microsoft documentation says:
http://msdn.microsoft.com/en-us/library/ie/hh869301(v=vs.85).aspx
http://msdn.microsoft.com/en-us/library/ie/ms537503(v=vs.85).aspx#TriToken

Besides this pull request, I have two things to mention:
1- This is already fixed in yui:
https://github.com/yui/yui3/commit/ff025179f3b6d324af30a905cd39a8bcbb31ab0b

2- I haven't included the IE11 compatible mode in the tests since the user agent in this case:
mozilla/4.0 (compatible; msie 7.0; windows nt 6.3; trident/7.0)

it doesn't contain the version (11) so our method com.liferay.portal.servlet.BrowserSnifferImpl.parseVersion() won't be able to get the proper version. I have created another LPS to do this task (https://issues.liferay.com/browse/LPS-43946) because it's not so urgent since we don't support IE compatible modes.

Thanks.
