### PR TITLE
[Technical-Support] LPS-48007 Web Content > Display Page > Private pages not listed after se...

### DIFF
--- a/portal-web/docroot/html/portlet/journal/article/display_page.jsp
+++ b/portal-web/docroot/html/portlet/journal/article/display_page.jsp
@@ -258,7 +258,7 @@ Group group = GroupLocalServiceUtil.fetchGroup(groupId);
 							tabView.render();
 
 							tabView.after(
-								'activeTabChange',
+								'selectionChange',
 								function() {
 									displayPageMessage('');
 


### PR DESCRIPTION
Hey Iliyan, did we support upgrading event names in `laut`? If so, we should add this one. `activeTabChange` does no longer exist in AlloyUI 2.0. We need to use `selectionChange` instead.
